### PR TITLE
make User model configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configuration options:
 - `auto_create` - Boolean (default: `false`). Whether to auto-create a local user from the remote user attributes.  Note: Also requires adding the Warden callbacks as shown below.
 - `auto_update` - Boolean (default: `false`). Whether to auto-update authenticated user attributes from remote user attributes.
 - `logout_url` - String (default: `'/'`).  For redirecting to a remote user logout URL after signing out of the Rails application.  Include `DeviseRemoteUser::ControllerBehavior` in your application controller to enable (by overriding Devise's `after_sign_out_path_for`).
+- `user_model` - String (default: `'User'`). If your your user model differs from `User`.
 
 Set options in a Rails initializer (e.g., `config/intializers/devise.rb`):
 
@@ -46,6 +47,7 @@ DeviseRemoteUser.configure do |config|
   config.auto_update = true
   config.attribute_map = {email: 'mail'}
   config.logout_url = "http://my.host/path.to.remote.logout"
+  config.user_model = "User"
 end
 ```
 

--- a/lib/devise_remote_user.rb
+++ b/lib/devise_remote_user.rb
@@ -32,6 +32,10 @@ module DeviseRemoteUser
   mattr_accessor :logout_url
   @@logout_url = '/'
 
+  # make User model configurable i.e. for usage in rails engines
+  mattr_accessor :user_model
+  @@user_model = 'User'
+
   def self.configure
     yield self
   end
@@ -43,6 +47,10 @@ module DeviseRemoteUser
     else
       env[env_key]
     end
+  end
+
+  def self.user_model
+    @@user_model.constantize
   end
 
 end

--- a/lib/devise_remote_user/manager.rb
+++ b/lib/devise_remote_user/manager.rb
@@ -22,13 +22,13 @@ module DeviseRemoteUser
     end
 
     def find_user
-      User.where(user_criterion).first
+      DeviseRemoteUser.user_model.where(user_criterion).first
     end
 
     def create_user
       random_password = SecureRandom.hex(16)
       attrs = user_criterion.merge({password: random_password, password_confirmation: random_password})
-      User.create(attrs)
+      DeviseRemoteUser.user_model.create(attrs)
     end
 
     def update_user(user)


### PR DESCRIPTION
Im using Devise within an rails engine, so my user model is namespaced like 'MyEngine::User'. Unfortunately the model User is hardcoded in lib/devise_remote_user/manager.rb.

With this patch you can set your user model. Default is 'User'.

What do you think?
