### PR TITLE
Replace update_attributes with update

### DIFF
--- a/lib/devise_remote_user/manager.rb
+++ b/lib/devise_remote_user/manager.rb
@@ -37,7 +37,7 @@ module DeviseRemoteUser
     end
 
     def update_user(user)
-      user.update_attributes(remote_user_attributes)
+      user.update(remote_user_attributes)
     end
 
     protected


### PR DESCRIPTION
update_attributes is deprecated. Thus devise-remote-user does not work in rails 6.1.0.rc2:

```
#<ActionView::Template::Error: undefined method `update_attributes' for #<User:0x00007fbe3148ab60>
Did you mean?  update_attribute>
```