### PR TITLE
Use github actions for CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,53 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.6, 2.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake ci
+      env:
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
+  test_rails5:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.6, 2.7]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+      env:
+        RAILS_VERSION: 5.2.4.4
+    - name: Run tests
+      run: bundle exec rake ci
+      env:
+        RAILS_VERSION: 5.2.4.4
+        ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ devise-remote-user
 A devise extension for remote user authentication.
 
 [![Gem Version](https://badge.fury.io/rb/devise-remote-user.svg)](http://badge.fury.io/rb/devise-remote-user)
-[![Build Status](https://travis-ci.org/duke-libraries/devise-remote-user.svg?branch=master)](https://travis-ci.org/duke-libraries/devise-remote-user)
+[![Build Status](https://github.com/duke-libraries/devise-remote-user/workflows/CI/badge.svg)](https://github.com/duke-libraries/devise-remote-user/actions?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/duke-libraries/devise-remote-user/badge.png?branch=master)](https://coveralls.io/r/duke-libraries/devise-remote-user?branch=master)
 [![Code Climate](https://codeclimate.com/github/duke-libraries/devise-remote-user/badges/gpa.svg)](https://codeclimate.com/github/duke-libraries/devise-remote-user)
 


### PR DESCRIPTION
Travisci.org is being decommissioned

https://docs.travis-ci.com/user/migrate/open-source-repository-migration#what-will-happen-to-my-travis-ciorg-repository